### PR TITLE
feat: move output helper to cuisto-api

### DIFF
--- a/packages/cuisto-api/package.json
+++ b/packages/cuisto-api/package.json
@@ -7,7 +7,8 @@
         "js-yaml": "^4.1.0",
         "execa": "^8.0.1",
         "ejs": "^3.1.9",
-        "isbinaryfile": "^5.0.2"
+        "isbinaryfile": "^5.0.2",
+        "ora": "^8.0.1"
     },
     "type": "module",
     "main": "./index.js"

--- a/packages/cuisto-api/src/lib/output.ts
+++ b/packages/cuisto-api/src/lib/output.ts
@@ -36,9 +36,10 @@ export const output = () => {
                 discardStdin: false,
             });
         },
-        errorAndExit: (message: string) => {
+        errorAndExit: (message: string): never => {
             console.error(error(message, false));
             process.exit(1);
         }
     };
 };
+

--- a/packages/cuisto-cli/package.json
+++ b/packages/cuisto-cli/package.json
@@ -8,7 +8,6 @@
     "ora": "^8.0.1",
     "@lazybobcat/cuisto-api": "0.0.5",
     "cosmiconfig": "^9.0.0",
-    "chalk": "^5.3.0",
     "xdg-basedir": "^5.1.0"
   },
   "type": "module",


### PR DESCRIPTION
Move the `output()` helper function to cuisto-api since it it used in both the cli and recipes and so that it can be properly typed in recipes.