### PR TITLE
fix: display errors from recipes even if verbose flag is not set

### DIFF
--- a/packages/cuisto-cli/src/cli.ts
+++ b/packages/cuisto-cli/src/cli.ts
@@ -90,18 +90,15 @@ program.parse(process.argv);
  * about the environment and the error that occurred.
  */
 process.setUncaughtExceptionCaptureCallback(async error => {
-    const verbosity = Number(process.env['VERBOSE']) || 0;
     const recipe = process.env['RECIPE_NAME'] || 'unknown';
     const dependencies: {[dep: string]: string} = JSON.parse(process.env['RECIPE_DEPENDENCIES'] || '') || {};
     const npm = await execa('npm', ['--version']);
-    if (verbosity > 0) {
-        verbose(error instanceof Error ? error.message : String(error), {verbose: verbosity});
-        printError(`An error occurred while executing the recipe "${recipe}".`);
-    } else {
 
-        printError(`An error occurred while executing the recipe "${recipe}". Please run the command with the --verbose option to get more information.`);
-    }
+    const message = error instanceof Error ? error.message : String(error);
+    printError(`An error occurred while executing the recipe "${recipe}".`);
+    console.error(`\n[ERROR] ${message}`);
 
+    console.log('\n'); // Add a line break to separate the error message from the previous output
     printInfo('If you consider opening an issue, please provide the following information:');
     console.log(`
 Cuisto:\t${metadata.default.version}

--- a/packages/cuisto-cli/src/lib/install.action.ts
+++ b/packages/cuisto-cli/src/lib/install.action.ts
@@ -85,7 +85,7 @@ export async function installAction(
 
     // Execute the recipe
     await asyncTask(
-        executeRecipe(recipeModule, vfs, path, schema, properties, options),
+        spinner => executeRecipe(recipeModule, vfs, path, schema, properties, options, spinner),
         info(`🍳 Cooking "${recipe}"...`, false)
     );
 
@@ -192,7 +192,7 @@ async function executeRecipe(
     schema: Schema,
     properties: FlatProperties,
     options: Options,
-    // progress: Ora
+    progress: Ora
 ) {
     verbose(`Execute recipe from ${path}/${schema.main}`, options);
 
@@ -204,7 +204,8 @@ async function executeRecipe(
 
     if (!options.dryRun && vfs.hasChanges()) {
         if (!options.yes) {
-            // progress.stopAndPersist();
+            progress.stopAndPersist();
+            console.log('\nThe following changes will be applied:');
             console.log(vfs.tree());
         }
         const answer = options.yes || await confirm({message: 'Do you want to write these files in your project?', default: false});


### PR DESCRIPTION
Display the errors happening in the CLI even if the `verbose` flag is not set so that we do not end up with an error that is not printed and avoid to re-execute a recipe with the `-v` flag.